### PR TITLE
[Codex] refine ts tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@types/luxon": "^3.6.2",
         "@types/morgan": "^1.9.9",
         "@types/node": "^22.15.29",
+        "@types/supertest": "^6.0.3",
         "eslint": "^9.28.0",
         "eslint-plugin-jest": "^28.12.0",
         "eslint-plugin-promise": "^7.2.1",
@@ -200,6 +201,8 @@
 
     "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
 
+    "@types/cookiejar": ["@types/cookiejar@2.1.5", "", {}, "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="],
+
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
@@ -218,11 +221,17 @@
 
     "@types/luxon": ["@types/luxon@3.6.2", "", {}, "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw=="],
 
+    "@types/methods": ["@types/methods@1.1.4", "", {}, "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ=="],
+
     "@types/morgan": ["@types/morgan@1.9.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-iRYSDKVaC6FkGSpEVVIvrRGw0DfJMiQzIn3qr2G5B3C//AWkulhXgaBd7tS9/J79GWSYMTHGs7PfI5b3Y8m+RQ=="],
 
     "@types/node": ["@types/node@22.15.29", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
+
+    "@types/superagent": ["@types/superagent@8.1.9", "", { "dependencies": { "@types/cookiejar": "^2.1.5", "@types/methods": "^1.1.4", "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ=="],
+
+    "@types/supertest": ["@types/supertest@6.0.3", "", { "dependencies": { "@types/methods": "^1.1.4", "@types/superagent": "^8.1.0" } }, "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w=="],
 
     "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/luxon": "^3.6.2",
     "@types/morgan": "^1.9.9",
     "@types/node": "^22.15.29",
+    "@types/supertest": "^6.0.3",
     "eslint": "^9.28.0",
     "eslint-plugin-jest": "^28.12.0",
     "eslint-plugin-promise": "^7.2.1",

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -35,8 +35,7 @@ const okResponse = (req: IncomingMessage, res: ServerResponse) =>
 const __filename = fileURLToPath(import.meta.url);
 const myTestPath = __filename.slice(__filename.lastIndexOf(path.sep, __filename.lastIndexOf(path.sep) - 1) + 1, __filename.length);
 
-const consoleStreams = console as unknown as ConsoleWithStreams &
-  Record<string, (...args: unknown[]) => void>;
+const consoleStreams = console as unknown as ConsoleWithStreams & Record<string, (...args: unknown[]) => void>;
 
 const methodLogger = logger as unknown as Record<LoggerMethods, (...args: unknown[]) => void>;
 const morganExtras = morgan as unknown as Record<string, unknown>;
@@ -74,7 +73,7 @@ describe('Logging', () => {
                     // Jest hooks consoleStreams._stderr up to stdout so we need to undo that to test here
                     const oldStderr = consoleStreams._stderr;
                     consoleStreams._stderr = process.stderr;
-                    const spyOnStream = spyOn((level == 'error' || level == 'debug') ? consoleStreams._stderr : consoleStreams._stdout, 'write').mockImplementation(() => true);
+                    const spyOnStream = spyOn((level == 'error' || level == 'debug') ? consoleStreams._stderr : consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
                     methodLogger[level as LoggerMethods]('hi');
                     consoleStreams._stderr = oldStderr;
 
@@ -85,7 +84,7 @@ describe('Logging', () => {
 
         it('logging should allow passing an object', () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
             methodLogger.info('hi', { some: 'object' });
 
             expect(spyOnStream).toHaveBeenCalledWith(expect.stringMatching(/\[INFO\] hi \{"some":"object"\}\n$/));
@@ -93,7 +92,7 @@ describe('Logging', () => {
 
         it('logging should allow empty message', () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
             methodLogger.info();
 
             expect(spyOnStream).toHaveBeenCalledWith(expect.stringMatching(/\[INFO\]\n$/));
@@ -101,7 +100,7 @@ describe('Logging', () => {
 
         it('logging should message with just object', () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
             methodLogger.info({ some: 'object' });
 
             expect(spyOnStream).toHaveBeenCalledWith(expect.stringMatching(/\[INFO\] \{"some":"object"\}\n$/));
@@ -151,7 +150,7 @@ describe('Logging', () => {
             _.forEach(['log', 'info', 'warn'], (level) => {
                 it(`Check level ${level} on console with no arg`, () => {
                     expect.assertions(1);
-                    const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+                    const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
                     logger.interceptConsole();
                     consoleStreams[level]();
                     logger.restoreConsole();
@@ -160,7 +159,7 @@ describe('Logging', () => {
 
                 it(`Check level ${level} on console`, () => {
                     expect.assertions(1);
-                    const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+                    const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
                     logger.interceptConsole();
                     consoleStreams[level]('hi');
                     logger.restoreConsole();
@@ -173,7 +172,7 @@ describe('Logging', () => {
                 // Jest hooks consoleStreams._stderr up to stdout so we need to undo that to test here
                 const oldStderr = consoleStreams._stderr;
                 consoleStreams._stderr = process.stderr;
-                const spyOnStream = spyOn(consoleStreams._stderr, 'write').mockImplementation(() => true);
+                const spyOnStream = spyOn(consoleStreams._stderr, 'write').mockImplementation(_.constant(true));
                 logger.interceptConsole();
                 console.error();
                 logger.restoreConsole();
@@ -187,7 +186,7 @@ describe('Logging', () => {
                 // Jest hooks consoleStreams._stderr up to stdout so we need to undo that to test here
                 const oldStderr = consoleStreams._stderr;
                 consoleStreams._stderr = process.stderr;
-                const spyOnStream = spyOn(consoleStreams._stderr, 'write').mockImplementation(() => true);
+                const spyOnStream = spyOn(consoleStreams._stderr, 'write').mockImplementation(_.constant(true));
                 logger.interceptConsole();
                 console.error('hi');
                 logger.restoreConsole();
@@ -198,7 +197,7 @@ describe('Logging', () => {
 
             it('Check dir helper on console', () => {
                 expect.assertions(1);
-                const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+                const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
                 logger.interceptConsole();
                 console.dir({ some: 'object' });
                 logger.restoreConsole();
@@ -209,7 +208,7 @@ describe('Logging', () => {
 
         it('console logging an empty message should work', () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
             logger.interceptConsole();
             console.log();
             logger.restoreConsole();
@@ -219,7 +218,7 @@ describe('Logging', () => {
 
         it('console logging overriding source should work', () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
             logger.interceptConsole();
             console.log('hi', { source: 'other' });
             logger.restoreConsole();
@@ -229,7 +228,7 @@ describe('Logging', () => {
 
         it('console logging an object should work', () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
             logger.interceptConsole();
             console.log('hi', { some: 'object' });
             logger.restoreConsole();
@@ -255,7 +254,7 @@ describe('Logging', () => {
 
         it('express middleware should log things', async () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
 
             return request(http.createServer(okResponse))
             .get('/some/path')
@@ -267,7 +266,7 @@ describe('Logging', () => {
 
         it('express middleware should create color formatter which is re-used', async () => {
             expect.assertions(6);
-            spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
             let origFormatter: unknown;
 
             return request(http.createServer(okResponse))
@@ -293,7 +292,7 @@ describe('Logging', () => {
 
         it('express middleware should handle request details', async () => {
             expect.assertions(1);
-            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+            const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
 
             return request(http.createServer((req, res) => {
                 return expressLogger(req, res, function onNext() {
@@ -319,7 +318,7 @@ describe('Logging', () => {
         ], (status_color) => {
             it(`express middleware should colorize status ${status_color[0]} properly`, async () => {
                 expect.assertions(2);
-                const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(() => true);
+                const spyOnStream = spyOn(consoleStreams._stdout, 'write').mockImplementation(_.constant(true));
 
                 return request(http.createServer((req, res) => {
                     return expressLogger(req, res, function onNext() {


### PR DESCRIPTION
## Summary
- replace eslint disable with real typings
- tighten console and logger casting
- satisfy TypeScript by returning booleans from mocked stream writes

## Testing
- `bun run lint`
- `npx tsc -p tsconfig.json`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6840d0212c70832f8cdabb5cdc5ff455